### PR TITLE
fix: ensure retry options are always positive

### DIFF
--- a/.changeset/perfect-icons-argue.md
+++ b/.changeset/perfect-icons-argue.md
@@ -1,0 +1,5 @@
+---
+"cypress-accessibility": patch
+---
+
+fix: ensure that retry options are always positive

--- a/docs/migrating-from-cypress-axe.md
+++ b/docs/migrating-from-cypress-axe.md
@@ -66,7 +66,7 @@ This `cypress-accessibility` feature allows you to chain the command to a specif
 -cy.checkA11y(null, null, null, true);
 +cy.checkAccessibility({
 +  shouldFail: () => false,
-});
++});
 ```
 
 #### With retries


### PR DESCRIPTION
Add some type narrowing for the `retry` options. If `interval` is set, the setting `limit` will also be required.